### PR TITLE
Add bash script to generate initial CSV

### DIFF
--- a/mediantime.sh
+++ b/mediantime.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+for HEIGHT in {0..630000}
+do
+    MEDIANTIME=$(bitcoin-cli getblockhash $HEIGHT | xargs bitcoin-cli getblockheader | jq .mediantime)
+    echo "$HEIGHT, $MEDIANTIME"
+done


### PR DESCRIPTION
To generate initial values, call the script like `./mediantime.sh > block-data.csv`.